### PR TITLE
Added support for searching by Workshop ID

### DIFF
--- a/Src/MainPage.cs
+++ b/Src/MainPage.cs
@@ -144,7 +144,8 @@ namespace KtaneWeb
                                 new DIV { class_ = "search-options" }._(
                                     new SPAN { class_ = "search-option", id = "search-opt-names" }._(new INPUT { type = itype.checkbox, class_ = "search-option-input", id = "search-names" }, new LABEL { for_ = "search-names" }._("Names")),
                                     new SPAN { class_ = "search-option", id = "search-opt-authors" }._(new INPUT { type = itype.checkbox, class_ = "search-option-input", id = "search-authors" }, new LABEL { for_ = "search-authors" }._("Authors")),
-                                    new SPAN { class_ = "search-option", id = "search-opt-descriptions" }._(new INPUT { type = itype.checkbox, class_ = "search-option-input", id = "search-descriptions" }, new LABEL { for_ = "search-descriptions" }._("Descriptions")))),
+                                    new SPAN { class_ = "search-option", id = "search-opt-descriptions" }._(new INPUT { type = itype.checkbox, class_ = "search-option-input", id = "search-descriptions" }, new LABEL { for_ = "search-descriptions" }._("Descriptions")),
+                                    new SPAN { class_ = "search-option", id = "search-opt-workshopids" }._(new INPUT { type = itype.checkbox, class_ = "search-option-input", id = "search-workshopids" }, new LABEL { for_ = "search-workshopids" }._("Workshop IDs")))),
                             new DIV { id = "rule-seed-mobile", class_ = "popup-link" }.Data("popup", "rule-seed")),
 
                         new DIV { id = "main-table-container" }._(

--- a/Src/Pdf.cs
+++ b/Src/Pdf.cs
@@ -51,7 +51,8 @@ namespace KtaneWeb
                     return keywords == null ||
                         (searchOptions.Contains("names") && keywords.All(k => m.Name.ContainsNoCase(k))) ||
                         (searchOptions.Contains("authors") && keywords.All(k => m.Author.ContainsNoCase(k))) ||
-                        (searchOptions.Contains("descriptions") && keywords.All(k => m.Description.ContainsNoCase(k)));
+                        (searchOptions.Contains("descriptions") && keywords.All(k => m.Description.ContainsNoCase(k))) ||
+                        (searchOptions.Contains("workshopids") && keywords.All(k => m.SteamID.ContainsNoCase(k)));
                 });
 
                 // Sort

--- a/Src/Pdf.cs
+++ b/Src/Pdf.cs
@@ -52,7 +52,7 @@ namespace KtaneWeb
                         (searchOptions.Contains("names") && keywords.All(k => m.Name.ContainsNoCase(k))) ||
                         (searchOptions.Contains("authors") && keywords.All(k => m.Author.ContainsNoCase(k))) ||
                         (searchOptions.Contains("descriptions") && keywords.All(k => m.Description.ContainsNoCase(k))) ||
-                        (searchOptions.Contains("workshopids") && keywords.All(k => m.SteamID.ContainsNoCase(k)));
+                        (searchOptions.Contains("workshopids") && keywords.All(k => m.SteamID.JsEscapeNull().Contains(k)));
                 });
 
                 // Sort

--- a/Src/Resources/KtaneWeb.ts
+++ b/Src/Resources/KtaneWeb.ts
@@ -182,7 +182,7 @@ function initializePage(modules: KtaneModuleInfo[], initIcons, initDocDirs, init
     var displayOptions = defaultDisplayOptions;
     try { displayOptions = JSON.parse(lStorage.getItem('display')) || defaultDisplayOptions; } catch (exc) { }
 
-    var validSearchOptions = ['names', 'authors', 'descriptions'];
+    var validSearchOptions = ['names', 'authors', 'descriptions', 'workshopids'];
     var defaultSearchOptions = ['names'];
     var searchOptions = defaultSearchOptions;
     try { searchOptions = JSON.parse(lStorage.getItem('searchOptions')) || defaultSearchOptions; } catch (exc) { }
@@ -709,6 +709,8 @@ function initializePage(modules: KtaneModuleInfo[], initIcons, initDocDirs, init
                 searchWhat += ' ' + mod.Author.toLowerCase();
             if (searchOptions.indexOf('descriptions') !== -1)
                 searchWhat += ' ' + mod.Description.toLowerCase();
+            if (searchOptions.indexOf('workshopids') !== -1)
+                searchWhat += ' ' + mod.SteamID;
             if (mod.Symbol)
                 searchWhat += ' ' + mod.Symbol.toLowerCase();
 


### PR DESCRIPTION
I noticed that certain mods had their modules split into multiple entries in the repository, like in [this example](https://steamcommunity.com/sharedfiles/filedetails/?id=729096093) where this mod is split into the Math module and the Emoji Math module. I thought it would be nice to add a search function to alleviate this issue.

It seems to work with any ID in my testing and doesn't appear to break anything else but I could be wrong in that regard. 