### PR TITLE
Fix resources paths for Linux

### DIFF
--- a/Lib/.gitignore
+++ b/Lib/.gitignore
@@ -1,1 +1,0 @@
-PdfSharp

--- a/Src/Resources.resx
+++ b/Src/Resources.resx
@@ -119,15 +119,15 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="Css" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>resources\ktaneweb.css;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>Resources\KtaneWeb.css;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="Js" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>resources\ktaneweb.js;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>Resources\KtaneWeb.js;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="PuzzlesCss" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>resources\puzzles.css;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>Resources\Puzzles.css;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="PuzzlesJs" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>resources\puzzles.js;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>Resources\Puzzles.js;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
 </root>


### PR DESCRIPTION
I was able to compile this project on linux with mono using these modifications. Related: #44 
Note: the setup is not fully functional since Rt.Util uses cmd.exe to clone the repositories