### PR TITLE
Scrolling, performance and other fixes

### DIFF
--- a/Src/MainPage.cs
+++ b/Src/MainPage.cs
@@ -323,6 +323,14 @@ namespace KtaneWeb
                                     new INPUT { type = itype.checkbox, class_ = "search-option-checkbox", id = "option-include-module-id" }, " ",
                                     new LABEL { for_ = "option-include-module-id" }._("Search by Module ID"))),
                             new DIV { class_ = "option-group" }._(
+                                new H4("Display results by"),
+                                new DIV(
+                                    new INPUT { type = itype.radio, class_ = "results-mode", id = "results-hide", name = "results-mode", value = "hide" }, " ",
+                                    new LABEL { for_ = "results-hide" }._("Hiding mods that don't match")),
+                                new DIV(
+                                    new INPUT { type = itype.radio, class_ = "results-mode", id = "results-scroll", name = "results-mode", value = "scroll" }, " ",
+                                    new LABEL { for_ = "results-scroll" }._("Scroll matching mod into view"))),
+                            new DIV { class_ = "option-group" }._(
                                 new H4("Site theme"),
                                 new DIV(
                                     new INPUT { type = itype.radio, class_ = "set-theme", name = "theme", id = "theme-default" }.Data("theme", "null"), " ",

--- a/Src/Resources/KtaneWeb.css
+++ b/Src/Resources/KtaneWeb.css
@@ -483,7 +483,7 @@ body.sort-published #main-table th.infos::after {
 div.popup {
     display: none;
     position: absolute;
-    border: 2px solid black;
+    border: 1px solid black;
     padding: 2em;
     background: #fafaff;
     box-shadow: 5px 5px 5px rgba(0,0,0,.3);

--- a/Src/Resources/KtaneWeb.js
+++ b/Src/Resources/KtaneWeb.js
@@ -787,7 +787,7 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
 
             if (searchRaw.toLocaleLowerCase().replace(/\s/g, '') === mod.Name.toLocaleLowerCase().replace(/\s/g, ''))
                 showAtTop.unshift(mod);
-            else if (mod.Symbol && searchRaw === mod.Symbol.toLowerCase())
+            else if (searchBySymbol && mod.Symbol && searchRaw === mod.Symbol.toLowerCase())
                 showAtTop.push(mod);
         });
 

--- a/Src/Resources/KtaneWeb.js
+++ b/Src/Resources/KtaneWeb.js
@@ -796,7 +796,7 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
         if ($("input#search-field").is(':focus'))
             updateSearchHighlight();
 
-        if (showAtTop !== showAtTopOfResults)
+        if (showAtTop.length !== showAtTopOfResults.length || !showAtTop.every(mod => showAtTopOfResults.includes(mod)))
         {
             showAtTopOfResults = showAtTop;
             setSort(sort, reverse);


### PR DESCRIPTION
- Added an option to scroll to each mod that matches the search results. This is much more performant than hiding the mods that don't match. Similar to the browser's CTRL+F but integrated better with the repo.
- The code wasn't properly checking to see if the mods that should show up at the top have changed which was slowing down the search.
- Made it only show symbol matches at the top if we're searching by the symbol.
- I thought it looked better if popups had the same border thickness as the main table.