### PR TITLE
Added Website to contact info services

### DIFF
--- a/Src/Resources/KtaneWeb.js
+++ b/Src/Resources/KtaneWeb.js
@@ -411,6 +411,7 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
             "Steam": "steamcommunity.com/",
             "Twitch": "twitch.tv/",
             "Twitter": "twitter.com/",
+            "Website": "",
             "YouTube": "youtube.com/",
         };
 


### PR DESCRIPTION
The idea is that people would add everything that comes after https:// to their contact info like so:
```
...
"LuminoscityTim" : {
    "Discord": "Luminoscity#3252",
    "GitHub": "Luminoscity",
    "Steam": "id/LuminoscityTim/",
    "Website": "lightsofluminoscity.com/",
    "YouTube": "channel/UCgLPaGtIPPiFu2YBlhyo-HA"
  },
...
```
I think it would be okay since we have maintainers for KtaneConent that can curate the safety and appropriateness of any requested website link additions.