### PR TITLE
Don't add a hidden input for the never serialized TwitchPlays field

### DIFF
--- a/Src/MainPage.cs
+++ b/Src/MainPage.cs
@@ -449,7 +449,8 @@ namespace KtaneWeb
                                 foreach (var field in typeToBeEdited.GetFields())
                                 {
                                     var attr = field.GetCustomAttribute<EditableFieldAttribute>();
-                                    if (attr != null && attr.ReadableName == null)
+                                    // The hidden TwitchPlays field is never serialized, so don't add a hidden input for it.
+                                    if (attr != null && attr.ReadableName == null && field.Name != "TwitchPlays")
                                         yield return new INPUT { type = itype.hidden, name = field.Name };
                                 }
                             }


### PR DESCRIPTION
Adding this causes the other TwitchPlays field (under Contributors) to not get included when generating JSONs.