### PR TITLE
Two improvements to existing features

### DIFF
--- a/Src/Resources/KtaneWeb.js
+++ b/Src/Resources/KtaneWeb.js
@@ -439,10 +439,11 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
                         for (const [service, username] of Object.entries(info))
                         {
                             const contactItem = el('li');
-                            if (services[service] === undefined)
+                            const correctedService = Object.keys(services).find(value => value.toLowerCase() == service.toLowerCase());
+                            if (services[correctedService] === undefined)
                                 contactItem.textContent = `${service}: ${username}`;
                             else
-                                contactItem.appendChild(el('a', null, service, { href: "https://" + services[service] + username }));
+                                contactItem.appendChild(el('a', null, correctedService, { href: "https://" + services[correctedService] + username }));
 
                             sublist.appendChild(contactItem);
                         }

--- a/Src/Resources/KtaneWeb.js
+++ b/Src/Resources/KtaneWeb.js
@@ -774,7 +774,7 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
             if (mod.Manuals.length > 0)
                 filteredIn = filteredIn && mod.Manuals.some(manual => preferredLanguages[manual.Language] !== false);
 
-            if (profileVetoList !== null)
+            if (profileVetoList !== null && mod.Origin !== 'Vanilla')
                 filteredIn = filteredIn && (profileVetoList.includes(mod.ModuleID) ? (filterVetoedByProfile || !filterEnabledByProfile) : (filterEnabledByProfile || !filterVetoedByProfile));
 
             let searchWhat = searchBySteamID ? (mod.SteamID || '') : '';


### PR DESCRIPTION
 - Capitalization is now ignored in service names. "Github" or "GitHub" will both work as the service name.
 - The profile filter would always filter out vanilla modules, so I've disabled that filter for vanilla modules.