### PR TITLE
Don't have links to interactive PDFs & Time Mode score display

### DIFF
--- a/Src/Enums.cs
+++ b/Src/Enums.cs
@@ -111,4 +111,16 @@
         [KtaneFilterOption("The module may not be republished and any work may not be reused.")]
         Restricted,
     }
+
+    public enum KtaneTimeModeOrigin
+    {
+        [KtaneFilterOption("This module does not have any assigned Time Mode score.")]
+        Unassigned,
+        [KtaneFilterOption("This module uses its Twitch Plays score as its Time Mode score.")]
+        TwitchPlays,
+        [KtaneFilterOption("This module has a community-assigned Time Mode score.")]
+        Community,
+        [KtaneFilterOption("This module has an assigned Time Mode score.")]
+        Assigned
+    }
 }

--- a/Src/KtaneModuleInfo.cs
+++ b/Src/KtaneModuleInfo.cs
@@ -91,6 +91,10 @@ namespace KtaneWeb
         [ClassifyIgnoreIfDefault, EditableField(null)]
         public KtaneTwitchPlaysInfo TwitchPlays = null;
 
+        // This information is imported from a spreadsheet, so not serialized in JSON.
+        [ClassifyIgnoreIfDefault, EditableField(null)]
+        public KtaneTimeModeInfo TimeMode = null;
+
         public object Icon(KtaneWebConfig config) => Path.Combine(config.BaseDir, "Icons", Name + ".png")
             .Apply(f => new IMG { class_ = "mod-icon", alt = Name, title = Name, src = $"data:image/png;base64,{Convert.ToBase64String(File.ReadAllBytes(File.Exists(f) ? f : Path.Combine(config.BaseDir, "Icons", "blank.png")))}" });
 
@@ -115,6 +119,7 @@ namespace KtaneWeb
                 other.Symbol == Symbol &&
                 other.TutorialVideoUrl == TutorialVideoUrl &&
                 Equals(other.TwitchPlays, TwitchPlays) &&
+                Equals(other.TimeMode, TimeMode) &&
                 other.Type == Type;
         }
 
@@ -235,6 +240,20 @@ namespace KtaneWeb
             other.Score == Score && other.ScorePerModule == ScorePerModule && other.ScorePerModuleCap == ScorePerModuleCap &&
             other.ScoreExplanation == ScoreExplanation && other.TagPosition == TagPosition && other.NeedyScoring == NeedyScoring && other.AutoPin == AutoPin;
         public override int GetHashCode() => Ut.ArrayHash(Score, ScorePerModule, ScorePerModuleCap, ScoreExplanation, TagPosition, NeedyScoring, AutoPin);
+    }
+
+    sealed class KtaneTimeModeInfo : IEquatable<KtaneTimeModeInfo>
+    {
+        [ClassifyIgnoreIfDefault, EditableIf(nameof(KtaneModuleInfo.Type), KtaneModuleType.Regular), EditableField("Score", "For regular modules, the score for solving it. For needy modules, depends on the scoring method.")]
+        public decimal? Score;
+        [ClassifyIgnoreIfDefault, EditableIf(nameof(KtaneModuleInfo.Type), KtaneModuleType.Regular), EditableField("Score per module", "For boss modules, a score value that is multiplied by the total number of modules on the bomb.")]
+        public decimal? ScorePerModule;          // for boss modules like FMN
+        [ClassifyIgnoreIfDefault, EditableIf(nameof(KtaneModuleInfo.Type), KtaneModuleType.Regular), EditableField("Score Origin", "The origin of this module's Time Mode score.")]
+        public KtaneTimeModeOrigin? Origin;
+
+        public override bool Equals(object obj) => obj != null && obj is KtaneTimeModeInfo && Equals((KtaneTimeModeInfo)obj);
+        public bool Equals(KtaneTimeModeInfo other) => other != null && other.Score == Score && other.ScorePerModule == ScorePerModule && other.Origin == Origin;
+        public override int GetHashCode() => Ut.ArrayHash(Score, ScorePerModule, Origin);
     }
 
     sealed class ContributorInfo : IEquatable<ContributorInfo>

--- a/Src/KtaneWebConfig.cs
+++ b/Src/KtaneWebConfig.cs
@@ -52,7 +52,7 @@ namespace KtaneWeb
                     if (!notModuleNames.Any(inf.File.Name.StartsWith))
                     {
                         list.Add($"{Path.GetFileNameWithoutExtension(inf.File.Name).Substring(moduleFileName.Length)}|{inf.File.Extension.Substring(1)}|{inf.Icon}");
-                        if (ext == "html")
+                        if (ext == "html" && !inf.File.Name.Contains("interactive"))
                             list.Add($"{Path.GetFileNameWithoutExtension(inf.File.Name).Substring(moduleFileName.Length)}|pdf|{inf.Icon + 2}");
                     }
             }

--- a/Src/MainPage.cs
+++ b/Src/MainPage.cs
@@ -97,6 +97,7 @@ namespace KtaneWeb
             (readable: "Difficulty", id: "difficulty"),
             (readable: "Origin", id: "origin"),
             (readable: "Twitch support", id: "twitch"),
+            (readable: "Time Mode score", id: "time-mode"),
             (readable: "Souvenir support", id: "souvenir"),
             (readable: "Rule seed support", id: "rule-seed"),
             (readable: "Date published", id: "published"),

--- a/Src/Resources/KtaneWeb.css
+++ b/Src/Resources/KtaneWeb.css
@@ -143,6 +143,39 @@ div.infos .inf-twitch {
         padding-right: 12px;
     }
 
+
+
+div.infos .inf-time-mode {
+    font-size: 10pt;
+}
+
+    div.infos .inf-time-mode::before, div.infos .inf-time-mode::before {
+        background-size: 12px 12px;
+        background-repeat: no-repeat;
+    }
+
+    div.infos .inf-time-mode::before {
+        background-position: right 4px;
+        background-position: calc(100% - 2px) 3px;
+        padding-right: 12px;
+    }
+
+    div.infos .inf-time-mode.inf-time-mode-Unassigned::before {
+        background-image: url(HTML/img/time-mode-Unassigned.svg);
+    }
+
+    div.infos .inf-time-mode.inf-time-mode-Assigned::before {
+        background-image: url(HTML/img/time-mode-Assigned.svg);
+    }
+
+    div.infos .inf-time-mode.inf-time-mode-Community::before {
+        background-image: url(HTML/img/time-mode-Community.svg);
+    }
+
+    div.infos .inf-time-mode.inf-time-mode-TwitchPlays::before {
+        background-image: url(HTML/img/time-mode-TwitchPlays.svg);
+    }
+
 div.infos .inf-rule-seed::before {
     background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1000"><path style="fill:%23026" d="M 778 0 C 720 0 662 21 618 65 C 553 131 536 226 568 307 L 308 567 C 227 534 131 551 66 616 C 10 672 -10 748 4 819 L 172 652 L 312 687 L 313 688 L 348 829 L 181 996 C 252 1010 329 990 384 935 C 449 869 466 773 433 692 L 692 433 C 774 466 871 450 937 384 C 992 328 1012 252 998 181 L 831 348 L 689 313 L 654 172 L 822 4 C 807 1 792 0 778 0 z"/></svg>');
     background-position: right 4px;
@@ -205,6 +238,7 @@ td.infos-1 div.infos > .inf-description {
 body:not(.display-difficulty) div.infos .inf-difficulty,
 body:not(.display-origin) div.infos .inf-origin,
 body:not(.display-twitch) div.infos .inf-twitch,
+body:not(.display-time-mode) div.infos .inf-time-mode,
 body:not(.display-rule-seed) div.infos .inf-rule-seed,
 body:not(.display-souvenir) div.infos .inf-souvenir,
 body:not(.display-id) div.infos .inf-id,
@@ -930,6 +964,7 @@ body.rule-seed-active #main-table-container #tabs > #rule-seed-link {
             body.display-origin td.infos-1 div.infos > div.inf-origin,
             body.display-published td.infos-1 div.infos > div.inf-published,
             body.display-twitch td.infos-1 div.infos > div.inf-twitch,
+            body.display-twitch td.infos-1 div.infos > div.inf-time-mode,
             body.display-souvenir td.infos-1 div.infos > div.inf-souvenir,
             body.display-rule-seed td.infos-1 div.infos > div.inf-rule-seed {
                 display: inline;
@@ -1115,6 +1150,17 @@ body.rule-seed-active #main-table-container #tabs > #rule-seed-link {
             }
 
                 #main-table td.infos-2 .inf-twitch::before {
+                    background-size: 7px 7px;
+                    background-position: 10px 3px;
+                    background-position: calc(100% - 2px) 3px;
+                    padding-right: 9px;
+                }
+
+            #main-table td.infos-2 .inf-time-mode {
+                font-size: inherit;
+            }
+
+                #main-table td.infos-2 .inf-time-mode::before {
                     background-size: 7px 7px;
                     background-position: 10px 3px;
                     background-position: calc(100% - 2px) 3px;

--- a/Src/Resources/KtaneWeb.js
+++ b/Src/Resources/KtaneWeb.js
@@ -121,6 +121,13 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
         "Frysk": "fy"
     };
 
+    const TimeModeNames = {
+        "Unassigned": "default",
+        "Assigned": "assigned",
+        "TwitchPlays": "Twitch Plays",
+        "Community": "community"
+    };
+
     var pageLang = window.location.search.match(/lang=([^?&]+)/);
     if (!pageLang || pageLang.length < 2 || Object.values(languageCodes).indexOf(pageLang[1]) === -1)
         pageLang = null;
@@ -179,7 +186,7 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
         sort = 'published';
     var reverse = lStorage.getItem('sort-reverse') == "true" || false;
 
-    var defaultDisplayOptions = ['author', 'type', 'difficulty', 'description', 'published', 'twitch', 'souvenir', 'rule-seed'];
+    var defaultDisplayOptions = ['author', 'type', 'difficulty', 'description', 'published', 'twitch', 'time-mode', 'souvenir', 'rule-seed'];
     var displayOptions = defaultDisplayOptions;
     try { displayOptions = JSON.parse(lStorage.getItem('display')) || defaultDisplayOptions; } catch (exc) { }
 
@@ -555,6 +562,15 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
                                 infos.append(el("div", "inf-twitch inf inf2", { title: mod.TwitchPlaysInfo },
                                     mod.TwitchPlays.ScorePerModule || mod.TwitchPlays.ScoreExplanation ? 'S' : mod.TwitchPlays.Score));
                             }
+                            if (mod.TimeMode)
+                            {
+                                if (mod.TimeMode.ScorePerModule)
+                                    mod.TimeModeInfo = `This module can be played in Time Mode for a score of ${mod.TimeMode.Score ? `${mod.TimeMode.Score}, plus ` : ''}${mod.TimeMode.ScorePerModule} for each module on the bomb${mod.TimeMode.Origin ? ` (${TimeModeNames[mod.TimeMode.Origin || 'Unassigned']} score)` : ''}.`;
+                                else
+                                    mod.TimeModeInfo = `This module can be played in Time Mode for a score of ${mod.TimeMode.Score}${mod.TimeMode.Origin ? ` (${TimeModeNames[mod.TimeMode.Origin || 'Unassigned']} score)` : ''}.`
+                                infos.append(el("div", `inf-time-mode inf-time-mode-${mod.TimeMode.Origin || 'Unassigned'} inf inf2`, { title: mod.TimeModeInfo },
+                                    mod.TimeMode.ScorePerModule ? 'S' : mod.TimeMode.Score));
+                            }
                             if (mod.RuleSeedSupport === 'Supported')
                             {
                                 mod.RuleSeedInfo = 'This module’s rules/manual can be dynamically varied using the Rule Seed Modifier.';
@@ -927,6 +943,8 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
                     menuDiv.appendChild(el('div', 'module-further-info', mod.SouvenirInfo));
                 if ($('#display-twitch').prop('checked') && 'TwitchPlaysInfo' in mod)
                     menuDiv.appendChild(el('div', 'module-further-info', mod.TwitchPlaysInfo));
+                if ($('#display-time-mode').prop('checked') && 'TimeModeInfo' in mod)
+                    menuDiv.appendChild(el('div', 'module-further-info', mod.TimeModeInfo));
                 if ($('#display-rule-seed').prop('checked') && 'RuleSeedInfo' in mod)
                     menuDiv.appendChild(el('div', 'module-further-info', mod.RuleSeedInfo));
                 var title = getCompatibilityText(mod);


### PR DESCRIPTION
Two features here:
 1. Interactive manuals no longer have links for PDFs (#49).
 2. Time Mode points now are a display option. The time mode icon is also colored to give an at-a-glance reference to the origin of the score (assigned, community, Twitch Plays, etc.)
 
 Corresponding `KtaneContent` PR: https://github.com/Timwi/KtaneContent/pull/1089