### PR TITLE
Fix periodic table displaying TP scores and score sort

### DIFF
--- a/Src/ModuleInfoCache.cs
+++ b/Src/ModuleInfoCache.cs
@@ -206,6 +206,8 @@ namespace KtaneWeb
 
             modJson["TwitchPlays"] = new JsonDict();
 
+            float score = 0;
+
             var parts = new List<string>();
             foreach (var factor in scoreString.SplitNoEmpty("+"))
             {
@@ -223,34 +225,41 @@ namespace KtaneWeb
                 if (!float.TryParse(numberString, out float number))
                     continue;
 
+                // We assume a bomb with 10 modules, 20 minutes, 65 seconds between activations and 10 actions to calculate scores.
                 switch (split.Length)
                 {
                     case 1:
                         parts.Add(number.Pluralize("base point"));
-                        mod.TwitchPlaysScore = number;
-                        modJson["TwitchPlays"]["Score"] = number;
+                        score += number;
                         break;
 
                     case 2 when split[0] == "T":
                         parts.Add(number.Pluralize("point") + " per second");
+                        score += 20 * 60 * number;
                         break;
 
                     // D is for needy deactivations.
                     case 2 when split[0] == "D":
                         parts.Add(number.Pluralize("point") + " per deactivation");
+                        score += 20 * 60 / 65 * number;
                         break;
 
                     // PPA is for point per action modules which can be parsed in some cases.
                     case 2 when split[0] == "PPA":
                         parts.Add(number.Pluralize("point") + " per action");
+                        score += 10 * number;
                         break;
 
                     // S is for special modules which we parse out the multiplier and put it into a dictionary and use later.
                     case 2 when split[0] == "S":
                         parts.Add(number.Pluralize("point") + " per module");
+                        score += 10 * number;
                         break;
                 }
             }
+
+            mod.TwitchPlaysScore = score;
+            modJson["TwitchPlays"]["Score"] = score;
 
             modJson["TwitchPlays"]["ScoreStringDescription"] = parts.JoinString(" + ");
         }

--- a/Src/Resources/KtaneWeb.js
+++ b/Src/Resources/KtaneWeb.js
@@ -629,11 +629,19 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
                 for (let i = 0; i < modules.length; i++)
                 {
                     let mod = modules[i];
+                    const tpScore = mod.TwitchPlays ? mod.TwitchPlays.ScoreStringDescription
+                        .replace(/( base)? points?/g, "")
+                        .replace("per", "P")
+                        .replace(" deactivation", "D")
+                        .replace(" action", "A")
+                        .replace(" second", "S")
+                        .replace(" module", "M") : '';
+
                     let manualSelector = el('a', 'manual-selector', { href: '#' });
                     let a = el('a', `module ${mod.ExpertDifficulty} compatibility-${mod.Compatibility}`,
                         el('div', `symbol ${mod.DefuserDifficulty}`, mod.Symbol || '??', el('div', 'mod-icon', { style: `background-position:-${mod.X * 32}px -${mod.Y * 32}px` })),
                         el('div', 'name', el('div', 'inner', mod.localName)),
-                        el('div', 'tpscore', mod.TwitchPlays ? mod.TwitchPlays.Score : ''),
+                        el('div', 'tpscore', tpScore),
                         el('div', 'souvenir', souvenirStatuses[(mod.Souvenir && mod.Souvenir.Status) || 'Unexamined']),
                         manualSelector);
                     setCompatibilityTooltip(a, mod.Compatibility);


### PR DESCRIPTION
Added some code for the periodic table to heavily shorten the score descriptions for TP. Also added some code to estimate the TP score for modules, so that modules can be sorted by score.