### PR TITLE
Text wrap in contributors field and All Contributors display option

### DIFF
--- a/Src/KtaneModuleInfo.cs
+++ b/Src/KtaneModuleInfo.cs
@@ -256,6 +256,7 @@ namespace KtaneWeb
         [ClassifyIgnoreIfDefault, EditableField("Idea", "People who contributed the original idea for the mod. (Include only if different from both Developer and Manual.)", AllowedSeparators = new[] { ',', ';' })]
         public string[] Idea;
 
+        public string ToAllAuthorString() => new[] { Developer, Manual, ManualGraphics, TwitchPlays, Maintainer, Audio, Modeling, Idea }.Where(authors => authors != null).SelectMany(authors => authors).Distinct().JoinString(", ");
         public string ToAuthorString() => new[] { Developer, Manual }.Where(authors => authors != null).SelectMany(authors => authors).Distinct().JoinString(", ");
 
         public override bool Equals(object obj) => obj != null && obj is ContributorInfo info && Equals(info);

--- a/Src/ModuleInfoCache.cs
+++ b/Src/ModuleInfoCache.cs
@@ -85,6 +85,9 @@ namespace KtaneWeb
 
                         if (string.IsNullOrEmpty(mod.Author) && mod.Contributors != null)
                             modJson["Author"] = mod.Contributors.ToAuthorString();
+                        modJson["AllContr"] = modJson["Author"];
+                        if (mod.Contributors != null)
+                            modJson["AllContr"] = mod.Contributors.ToAllAuthorString();
 
                         return (modJson, mod, file.LastWriteTimeUtc).Nullable();
                     }

--- a/Src/Pdf.cs
+++ b/Src/Pdf.cs
@@ -162,6 +162,7 @@ namespace KtaneWeb
                 var searchBySymbol = json["searchBySymbol"].GetBoolSafe() ?? false;
                 var searchBySteamID = json["searchBySteamID"].GetBoolSafe() ?? false;
                 var searchByModuleID = json["searchByModuleID"].GetBoolSafe() ?? false;
+                var displayAllContributors = json["dispAllContr"].GetBoolSafe() ?? false;
 
                 static string unifyString(string str) => Regex.Replace(str.Normalize(NormalizationForm.FormD), @"[\u0300-\u036f]", "").Replace("grey", "gray").Replace("colour", "color");
 
@@ -192,7 +193,10 @@ namespace KtaneWeb
                     if (searchOptions.Contains("names"))
                         searchWhat += " " + m.Name.ToLowerInvariant() + " " + m.SortKey.ToLowerInvariant();
                     if (searchOptions.Contains("authors") && (m.Author != null || m.Contributors != null))
-                        searchWhat += " " + (m.Author ?? m.Contributors.ToAuthorString()).ToLowerInvariant();
+                        if (displayAllContributors)
+                            searchWhat += " " + (m.Author ?? m.Contributors.ToAllAuthorString()).ToLowerInvariant();
+                        else
+                            searchWhat += " " + (m.Author ?? m.Contributors.ToAuthorString()).ToLowerInvariant();
                     if (searchOptions.Contains("descriptions"))
                         searchWhat += " " + m.Description.ToLowerInvariant();
                     if (searchBySymbol && m.Symbol != null)

--- a/Src/Resources/KtaneWeb.css
+++ b/Src/Resources/KtaneWeb.css
@@ -229,6 +229,10 @@ div.infos .inf-author, div.infos .inf-published {
         content: '\000a by ';
         white-space: pre;
     }
+    div.infos .inf-author::after {
+        content: '\0020 ';
+        white-space: normal;
+    }
 
     div.infos .inf-author span.contributors {
         text-decoration: underline dotted;

--- a/Src/Resources/KtaneWeb.css
+++ b/Src/Resources/KtaneWeb.css
@@ -282,7 +282,9 @@ body:not(.display-rule-seed) div.infos .inf-rule-seed,
 body:not(.display-souvenir) div.infos .inf-souvenir,
 body:not(.display-id) div.infos .inf-id,
 body:not(.display-description) div.infos .inf-description,
-body:not(.display-published) div.infos .inf-published {
+body:not(.display-published) div.infos .inf-published,
+body:not(.display-all-contributors) div.infos .inf-author.all-contributors,
+body.display-all-contributors div.infos .inf-author:not(.all-contributors) {
     display: none;
 }
 

--- a/Src/Resources/KtaneWeb.css
+++ b/Src/Resources/KtaneWeb.css
@@ -346,7 +346,12 @@ tr.mod.compatibility-Problematic .mod-name::before, #actual-periodic-table a.com
         box-sizing: border-box;
     }
 
-    #main-table th, #main-table td.infos-2 {
+    #main-table th,
+    #main-table td.infos-2 .inf-difficulty,
+    #main-table td.infos-2 .inf-published,
+    #main-table td.infos-2 .inf-twitch,
+    #main-table td.infos-2 .inf-time-mode
+    {
         white-space: nowrap;
     }
 

--- a/Src/Resources/KtaneWeb.js
+++ b/Src/Resources/KtaneWeb.js
@@ -430,17 +430,16 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
             "YouTube": "youtube.com/",
         };
 
-        function makeAuthorElement(mod, allContributorsEnabled)
+        function makeAuthorElement(mod)
         {
             const title = mod.Contributors === undefined ? '' : Object.entries(mod.Contributors).filter(([_, names]) => names != null).map(([role, names]) => `${role}: ${names.join(', ')}`).join('\n');
-            let namesSet = new Set();
-            if (mod.Contributors)
-                for (let key of Object.keys(mod.Contributors))
-                    for (let contributor of mod.Contributors[key])
-                        namesSet.add(contributor);
-            let names = Array.from(namesSet);
-            const author = allContributorsEnabled ? (mod.Contributors === undefined ? mod.Author : names.join(', ')) : mod.Author;
-            return el('div', 'inf-author inf', el('span', 'contributors', author), { title: title });
+            return el('div', 'inf-author inf', el('span', 'contributors', mod.Author), { title: title });
+        }
+
+        function makeAllAuthorElement(mod) {
+            const title = mod.Contributors === undefined ? '' : Object.entries(mod.Contributors).filter(([_, names]) => names != null).map(([role, names]) => `${role}: ${names.join(', ')}`).join('\n');
+            const author = mod.Contributors === undefined ? mod.Author : mod.AllContr;
+            return el('div', 'inf-author all-contributors inf', el('span', 'contributors', author), { title: title });
         }
 
         function addAuthorClick(element, mod)
@@ -583,9 +582,7 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
                                 else
                                     infos.append(el("div", "inf-difficulty inf inf2", el("span", "inf-difficulty-sub", readable(mod.DefuserDifficulty)), ' (d), ', el("span", "inf-difficulty-sub", readable(mod.ExpertDifficulty)), ' (e)'));
                             }
-                            var allContributorsEnabled = false;
-                            try { allContributorsEnabled = (JSON.parse(lStorage.getItem('display')) || []).includes('all-contributors') } catch (exc) { }
-                            infos.append(makeAuthorElement(mod, allContributorsEnabled),
+                            infos.append(makeAuthorElement(mod), makeAllAuthorElement(mod),
                                 el("div", "inf-published inf inf2", mod.Published));
                             if (mod.TwitchPlays)
                             {
@@ -623,6 +620,8 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
 
                             addAuthorClick(td1.querySelector(".inf-author"), mod);
                             addAuthorClick(td2.querySelector(".inf-author"), mod);
+                            addAuthorClick(td1.querySelector(".inf-author.all-contributors"), mod);
+                            addAuthorClick(td2.querySelector(".inf-author.all-contributors"), mod);
 
                             var lnk1 = el("a", "manual-selector", { href: "#" });
                             lnk1.onclick = makeClickHander(lnk1, false, mod);

--- a/Src/TranslationInfo.cs
+++ b/Src/TranslationInfo.cs
@@ -176,7 +176,7 @@ namespace KtaneWeb
         public string displayDate = "Date published";
         public string displayID = "Module ID";
         public string displayUpdated = "Last updated";
-        public string displayAllContributors = "All Contributors";
+        public string displayAllContributors = "All contributors";
         public string searchOption = "Search options";
         public string searchSteamID = "Search by Steam ID";
         public string searchSymbol = "Search by Symbol";

--- a/Src/TranslationInfo.cs
+++ b/Src/TranslationInfo.cs
@@ -176,6 +176,7 @@ namespace KtaneWeb
         public string displayDate = "Date published";
         public string displayID = "Module ID";
         public string displayUpdated = "Last updated";
+        public string displayAllContributors = "All Contributors";
         public string searchOption = "Search options";
         public string searchSteamID = "Search by Steam ID";
         public string searchSymbol = "Search by Symbol";
@@ -262,7 +263,9 @@ namespace KtaneWeb
             (readable: displayRuleSeed, id: "rule-seed"),
             (readable: displayDate, id: "published"),
             (readable: displayID, id: "id"),
-            (readable: displayUpdated, id: "last-updated")).WhereNotNull().ToArray();
+            (readable: displayUpdated, id: "last-updated"),
+            (readable: displayAllContributors, id: "all-contributors")
+            ).WhereNotNull().ToArray();
 
         [ClassifyIgnore]
         public string Json;


### PR DESCRIPTION
"All contributors" checkbox in the Display section of the Options tab that displays all contributors in the right column on the home page.
The elements after the contributors field (published date, etc.) now wrap to the next line when needed whether or not this checkbox is enabled.