### PR TITLE
Add optional Custom Difficulty fields to KtaneModuleInfo

### DIFF
--- a/Src/KtaneModuleInfo.cs
+++ b/Src/KtaneModuleInfo.cs
@@ -68,6 +68,13 @@ namespace KtaneWeb
         [EditableField("Expert difficulty", "An approximate difficulty rating for the expert.")]
         public KtaneModuleDifficulty? ExpertDifficulty;
 
+        [ClassifyIgnoreIfDefault, EditableIf(nameof(Type), KtaneModuleType.Regular, KtaneModuleType.Needy, KtaneModuleType.Holdable)]
+        [EditableField("Custom difficulty (D)", "An optional alternative defuser difficulty descriptor, limted to 12 characters.")]
+        public string CustomDefuserDifficulty = null;
+        [ClassifyIgnoreIfDefault, EditableIf(nameof(Type), KtaneModuleType.Regular, KtaneModuleType.Needy, KtaneModuleType.Holdable)]
+        [EditableField("Custom difficulty (E)", "An optional alternative expert difficulty descriptor, limted to 12 characters.")]
+        public string CustomExpertDifficulty = null;
+
         [ClassifyIgnoreIfDefault, EditableField("Rule-seed", "Does the module vary its rules and manual under the Rule Seed Modifier?")]
         public KtaneSupport RuleSeedSupport = KtaneSupport.NotSupported;
 
@@ -140,11 +147,18 @@ namespace KtaneWeb
             {
                 DefuserDifficulty ??= KtaneModuleDifficulty.Easy;
                 ExpertDifficulty ??= KtaneModuleDifficulty.Easy;
+                int lim = 12;
+                if (CustomDefuserDifficulty != null)
+                    CustomDefuserDifficulty = CustomDefuserDifficulty.Substring(0, CustomDefuserDifficulty.Length <= lim ? CustomDefuserDifficulty.Length : lim);
+                if (CustomExpertDifficulty != null)
+                    CustomExpertDifficulty = CustomExpertDifficulty.Substring(0, CustomExpertDifficulty.Length <= lim ? CustomExpertDifficulty.Length : lim);
             }
             else
             {
                 DefuserDifficulty = null;
                 ExpertDifficulty = null;
+                CustomDefuserDifficulty = null;
+                CustomExpertDifficulty = null;
                 RuleSeedSupport = KtaneSupport.NotSupported;
             }
 

--- a/Src/Resources/KtaneWeb.css
+++ b/Src/Resources/KtaneWeb.css
@@ -327,6 +327,8 @@ body:not(.display-id) div.infos .inf-id,
 body:not(.display-description) div.infos .inf-description-only,
 body:not(.display-tags) div.infos .inf-tags,
 body:not(.display-published) div.infos .inf-published,
+body:not(.display-custom-difficulty) div.infos .inf.inf2.inf-difficulty.custom-difficulty,
+body.display-custom-difficulty div.infos .inf.inf2.inf-difficulty.real-difficulty,
 body:not(.display-all-contributors) div.infos .inf-author.all-contributors,
 body.display-all-contributors div.infos .inf-author:not(.all-contributors) {
     display: none;

--- a/Src/Resources/KtaneWeb.css
+++ b/Src/Resources/KtaneWeb.css
@@ -1105,6 +1105,7 @@ body.rule-seed-active #main-table-container #tabs > #rule-seed-link {
                 display: inline;
             }
 
+            td.infos-1 div.infos > div.inf-id::before,
             td.infos-1 div.infos > div.inf2::before {
                 content: '\a0 • ';
             }

--- a/Src/Resources/KtaneWeb.js
+++ b/Src/Resources/KtaneWeb.js
@@ -598,10 +598,24 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
                                     }
                                     return result;
                                 }
-                                if (mod.DefuserDifficulty === mod.ExpertDifficulty)
-                                    infos.append(el("div", "inf-difficulty inf inf2", el("span", "inf-difficulty-sub", readable(mod.DefuserDifficulty))));
+                                function customDifficulty(custDifficulty, realDifficulty)
+                                {
+                                    if (custDifficulty)
+                                        return el("span", "inf-difficulty-sub", { title: readable(realDifficulty) }, custDifficulty);
+                                    return el("span", "inf-difficulty-sub", readable(realDifficulty));
+                                }
+
+                                if (mod.CustomDefuserDifficulty && mod.CustomExpertDifficulty && mod.CustomDefuserDifficulty === mod.CustomExpertDifficulty)
+                                    infos.append(el("div", "inf-difficulty custom-difficulty inf inf2", el("span", "inf-difficulty-sub", customDifficulty(mod.CustomDefuserDifficulty, mod.DefuserDifficulty))));
+                                else if (!mod.CustomDefuserDifficulty && !mod.CustomExpertDifficulty && mod.DefuserDifficulty === mod.ExpertDifficulty)
+                                    infos.append(el("div", "inf-difficulty custom-difficulty inf inf2", el("span", "inf-difficulty-sub", readable(mod.DefuserDifficulty))));
                                 else
-                                    infos.append(el("div", "inf-difficulty inf inf2", el("span", "inf-difficulty-sub", readable(mod.DefuserDifficulty)), ' (d), ', el("span", "inf-difficulty-sub", readable(mod.ExpertDifficulty)), ' (e)'));
+                                    infos.append(el("div", "inf-difficulty custom-difficulty inf inf2", customDifficulty(mod.CustomDefuserDifficulty, mod.DefuserDifficulty), ' (d), ', customDifficulty(mod.CustomExpertDifficulty, mod.ExpertDifficulty), ' (e)'));
+
+                                if (mod.DefuserDifficulty === mod.ExpertDifficulty)
+                                    infos.append(el("div", "inf-difficulty real-difficulty inf inf2", el("span", "inf-difficulty-sub", readable(mod.DefuserDifficulty))));
+                                else
+                                    infos.append(el("div", "inf-difficulty real-difficulty inf inf2", el("span", "inf-difficulty-sub", readable(mod.DefuserDifficulty)), ' (d), ', el("span", "inf-difficulty-sub", readable(mod.ExpertDifficulty)), ' (e)'));
                             }
                             infos.append(makeAuthorElement(mod), makeAllAuthorElement(mod),
                                 el("div", "inf-published inf inf2", mod.Published));
@@ -1765,7 +1779,7 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
     function setEditUi(mod)
     {
         let ui = document.getElementById('module-ui');
-        for (let key of 'Name,Description,ModuleID,SortKey,SteamID,Author,SourceUrl,Symbol,Type,Origin,Compatibility,CompatibilityExplanation,Published,DefuserDifficulty,ExpertDifficulty,TranslationOf,RuleSeedSupport,BossStatus,MysteryModule'.split(','))
+        for (let key of 'Name,Description,ModuleID,SortKey,SteamID,Author,SourceUrl,Symbol,Type,Origin,Compatibility,CompatibilityExplanation,Published,DefuserDifficulty,ExpertDifficulty,CustomDefuserDifficulty,CustomExpertDifficulty,TranslationOf,RuleSeedSupport,BossStatus,MysteryModule'.split(','))
             ui.querySelector(`[name="${key}"]`).value = (mod[key] || '');
 
         if (!mod['BossStatus'] && Object.keys(mod).length > 0)

--- a/Src/TranslationInfo.cs
+++ b/Src/TranslationInfo.cs
@@ -182,6 +182,7 @@ namespace KtaneWeb
         public string displayDate = "Date published";
         public string displayID = "Module ID";
         public string displayUpdated = "Last updated";
+        public string displayCustomDifficulty = "Custom Difficulty";
         public string displayAllContributors = "All contributors";
         public string searchOption = "Search options";
         public string searchSteamID = "Search by Steam ID";
@@ -275,6 +276,7 @@ namespace KtaneWeb
             (readable: displayDate, id: "published"),
             (readable: displayID, id: "id"),
             (readable: displayUpdated, id: "last-updated"),
+            (readable: displayCustomDifficulty, id: "custom-difficulty"),
             (readable: displayAllContributors, id: "all-contributors")
             ).WhereNotNull().ToArray();
 


### PR DESCRIPTION
Add optional custom Difficulty fields to KtaneModuleInfo
  They can be switched off in the Options menu
  If on, the custom ones are displayed instead of the "real" difficulties
  "Real" ones shown if no custom ones defined
  Tooltip over custom ones shows the "real" ones

Fix spacing of Module ID in narrow window mode