### PR TITLE
Open Source Clone license type

### DIFF
--- a/Src/Enums.cs
+++ b/Src/Enums.cs
@@ -84,6 +84,8 @@ namespace KtaneWeb
     {
         [KtaneFilterOption(nameof(TranslationInfo.licenseOpenSource))]
         OpenSource,
+        [KtaneFilterOption(nameof(TranslationInfo.licenseOpenSourceClone))]
+        OpenSourceClone,
         [KtaneFilterOption(nameof(TranslationInfo.licenseRepublishable))]
         Republishable,
         [KtaneFilterOption(nameof(TranslationInfo.licenseRestricted))]

--- a/Src/KtaneModuleInfo.cs
+++ b/Src/KtaneModuleInfo.cs
@@ -184,7 +184,7 @@ namespace KtaneWeb
             if (Symbol != null && Symbol.Length > 0)
                 Symbol = Symbol.Substring(0, 1).ToUpperInvariant() + Symbol.Substring(1).ToLowerInvariant();
 
-            if (SourceUrl != null)
+            if (SourceUrl != null && License != KtaneModuleLicense.OpenSourceClone)
                 License = KtaneModuleLicense.OpenSource;
         }
 

--- a/Src/Resources/KtaneWeb.js
+++ b/Src/Resources/KtaneWeb.js
@@ -582,7 +582,8 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
                                 tr.appendChild(td);
                                 if (sel.ShowIconFunction(mod, mod.Manuals))
                                 {
-                                    let iconImg = el("img", "icon", { title: sel.HumanReadable, alt: sel.HumanReadable, src: sel.Icon });
+                                    let humanReadable = sel.HumanReadableFunction ? sel.HumanReadableFunction(mod, mod.Manuals) : sel.HumanReadable;
+                                    let iconImg = el("img", "icon", { title: humanReadable, alt: humanReadable, src: sel.IconFunction(mod, mod.Manuals) });
                                     if (sel.PropName === 'video' && (mod.TutorialVideos && mod.TutorialVideos.length > 1))
                                     {
                                         let lnkDiv = el("div", "dropdown", iconImg);
@@ -1161,8 +1162,8 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
                         continue;
                     var iconDiv = el('div', 'icon',
                         el('a', 'icon-link', { href: sel.UrlFunction(mod, mod.Manuals) },
-                            el('img', 'icon-img', { src: sel.Icon }),
-                            el('span', 'icon-label', sel.HumanReadable)));
+                            el('img', 'icon-img', { src: sel.IconFunction(mod, mod.Manuals) }),
+                            el('span', 'icon-label', sel.HumanReadableFunction ? sel.HumanReadableFunction(mod, mod.Manuals) : sel.HumanReadable)));
                     iconsDiv.appendChild(iconDiv);
                 }
 
@@ -1920,7 +1921,7 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
 
         const license = ui.querySelector('select[name="License"]');
         const agreement = ui.querySelector('#license-agreement');
-        agreement.style.display = license.value == "OpenSource" ? '' : 'none';
+        agreement.style.display = license.value == "OpenSource" || license.value == "OpenSourceClone" ? '' : 'none';
     }
     Array.from(document.getElementById('module-ui').querySelectorAll('input,textarea,select')).forEach(elem => { elem.onchange = UpdateEditUiElements; });
     UpdateEditUiElements();
@@ -1934,22 +1935,23 @@ function initializePage(modules, initIcons, initDocDirs, initDisplays, initFilte
     document.getElementById('generate-json').onclick = function(e)
     {
         let form = document.getElementById('generate-json').form;
+        let openSource = form.License.value === "OpenSource" || form.License.value === "OpenSourceClone";
         if (form.Name.value === "")
         {
             alert("You do need to supply at least a name for the module or widget.");
             return false;
         }
-        else if (form.SourceUrl.value === "" && form.License.value === "OpenSource")
+        else if (form.SourceUrl.value === "" && openSource)
         {
             alert("A link to the source code must be provided to use the open source license.");
             return false;
         }
-        else if (form.SourceUrl.value !== "" && form.License.value !== "OpenSource")
+        else if (form.SourceUrl.value !== "" && !openSource)
         {
-            alert("If a link to the source code is provided then you must use the open source license.");
+            alert("If a link to the source code is provided then you must use the open source or the open source clone license.");
             return false;
         }
-        else if (form.License.value === "OpenSource" && !form.LicenseAgreement.checked)
+        else if (openSource && !form.LicenseAgreement.checked)
         {
             alert("You must read and agree to the modkit license.");
             return false;

--- a/Src/Selectable.cs
+++ b/Src/Selectable.cs
@@ -4,10 +4,11 @@ namespace KtaneWeb
 {
     sealed class Selectable
     {
-        public string HumanReadable;
         public char? Accel;
-        public string Icon;
         public string PropName;
+        public string HumanReadable;
+        public string HumanReadableFunction;
+        public string IconFunction;
         public string UrlFunction;
         public string ShowIconFunction;
 
@@ -15,14 +16,15 @@ namespace KtaneWeb
         {
             var dict = new JsonDict();
 
-            // Strings
-            if (HumanReadable != null) dict["HumanReadable"] = HumanReadable;
-            if (Icon != null) dict["Icon"] = Icon;
-            if (PropName != null) dict["PropName"] = PropName;
+            // String
+            if (PropName != null) dict[nameof(PropName)] = PropName;
+            if (HumanReadable != null) dict[nameof(HumanReadable)] = HumanReadable;
 
             // Functions
-            if (UrlFunction != null) dict["UrlFunction"] = new JsonRaw(UrlFunction);
-            if (ShowIconFunction != null) dict["ShowIconFunction"] = new JsonRaw(ShowIconFunction);
+            if (HumanReadableFunction != null) dict[nameof(HumanReadableFunction)] = new JsonRaw(HumanReadableFunction);
+            if (IconFunction != null) dict[nameof(IconFunction)] = new JsonRaw(IconFunction);
+            if (UrlFunction != null) dict[nameof(UrlFunction)] = new JsonRaw(UrlFunction);
+            if (ShowIconFunction != null) dict[nameof(ShowIconFunction)] = new JsonRaw(ShowIconFunction);
 
             return dict;
         }

--- a/Src/TranslationInfo.cs
+++ b/Src/TranslationInfo.cs
@@ -121,6 +121,7 @@ namespace KtaneWeb
         public string filterMMNotUse = "MM must not use this at all";
         public string filterMMAutoSovle = "MM must auto-solve";
         public string licenseOpenSource = "The module has its source code released and will follow the module’s license.";
+        public string licenseOpenSourceClone = "The module's source code is a clone/fork of its original repository, and will follow the license of the original.";
         public string licenseRepublishable = "The module may be republished on someone else’s Steam account. Any work may not be reused.";
         public string licenseRestricted = "The module may not be republished and any work may not be reused.";
         public string bossStatusFullBoss = "Full Boss";
@@ -167,6 +168,7 @@ namespace KtaneWeb
         public string selectableManual = "Manual";
         public string selectableSteam = "Steam Workshop";
         public string selectableSource = "Source code";
+        public string selectableSourceClone = "Source code (clone)";
         public string selectableTutorial = "Tutorial videos";
         public string displayOption = "Display";
         public string displayOriginalName = "Original Name";
@@ -225,37 +227,38 @@ namespace KtaneWeb
         public Selectable[] Selectables => _selectablesCache ??= Ut.NewArray(
             new Selectable
             {
-                HumanReadable = selectableManual,
                 Accel = 'u',
-                Icon = "HTML/img/manual.png",
                 PropName = "manual",
+                HumanReadable = selectableManual,
+                IconFunction = @"mod=>'HTML/img/manual.png'",
                 UrlFunction = @"mod=>mod.ManualIconUrl",
                 ShowIconFunction = @"(_,s)=>s.length>0"
             },
             new Selectable
             {
-                HumanReadable = selectableSteam,
                 Accel = 'W',
-                Icon = "HTML/img/steam-workshop-item.png",
                 PropName = "steam",
+                HumanReadable = selectableSteam,
+                IconFunction = @"mod=>'HTML/img/steam-workshop-item.png'",
                 UrlFunction = @"mod=>mod.SteamID?`http://steamcommunity.com/sharedfiles/filedetails/?id=${mod.SteamID}`:null",
                 ShowIconFunction = @"mod=>!!mod.SteamID",
             },
             new Selectable
             {
-                HumanReadable = selectableSource,
                 Accel = 'c',
-                Icon = "HTML/img/unity.png",
                 PropName = "source",
+                HumanReadable = selectableSource,
+                HumanReadableFunction = @$"mod=>mod.License==='OpenSourceClone'?'{selectableSourceClone}':'{selectableSource}'",
+                IconFunction = @"mod=>mod.License==='OpenSourceClone'?'HTML/img/unity-clone.png':'HTML/img/unity.png'",
                 UrlFunction = @"mod=>mod.SourceUrl",
                 ShowIconFunction = @"mod=>!!mod.SourceUrl",
             },
             new Selectable
             {
-                HumanReadable = selectableTutorial,
                 Accel = 'T',
-                Icon = "HTML/img/video.png",
                 PropName = "video",
+                HumanReadable = selectableTutorial,
+                IconFunction = @"mod=>'HTML/img/video.png'",
                 UrlFunction = @"mod=>mod.TutorialVideos&&mod.TutorialVideos[0].Url",
                 ShowIconFunction = @"mod=>!!mod.TutorialVideos&&mod.TutorialVideos.length>0",
             });


### PR DESCRIPTION
Added a license option for modules that had their original source code removed, but a public clone/fork of them exists. If the module has this license type selected, the icon and title of the source code link will change to signal the fact that it's not the original repo to the user.

In tandem, also added the option for selectables to have multiple possible states by making the `Icon` and `HumanReadable` fields functions.