### PR TITLE
Fix more Section/Appendix remove cases for /json/startingline.

### DIFF
--- a/Src/ModuleInfoCache.cs
+++ b/Src/ModuleInfoCache.cs
@@ -56,7 +56,7 @@ namespace KtaneWeb
                 else if (startingLine == null)
                 {
                     var text = tag.InnerText;
-                    if (!text.ContainsIgnoreCase("Appendix") && !text.ContainsIgnoreCase("SECTION") && !text.ContainsIgnoreCase("appendices") && !text.ContainsIgnoreCase("you are looking at a different") && !text.ContainsIgnoreCase("you are looking at the wrong"))
+                    if (!text.ContainsIgnoreCase(" Appendix ") && !text.Contains(" SECTION ") && !text.ContainsIgnoreCase(" appendices ") && !text.ContainsIgnoreCase("you are looking at a different") && !text.ContainsIgnoreCase("you are looking at the wrong"))
                         startingLine = Regex.Replace(text, @"\s+", " ").Trim();
                 }
             }


### PR DESCRIPTION
Oops! Modules like Extended Boolean Venn Diagram or Not X01 got caught in the crossfire of Radio's "SECTION" check.

Update makes such checks less likely to hit false positives, especially with "section".