### PR TITLE
Allow redirect to use rule seeds

### DIFF
--- a/Src/Resources/Redirect.html
+++ b/Src/Resources/Redirect.html
@@ -21,7 +21,12 @@
 			let redirectTo = inf && hash in inf
 				? `${hash} ${inf[hash].replace(/ \((HTML|PDF)\)$/, (_, e) => `.${e.toLowerCase()}`)}`
 				: `${hash}.html`;
-			window.location.replace(`../HTML/${encodeURIComponent(redirectTo)}`);
+
+			let urlParams = new URLSearchParams(window.location.search);
+			let seed = parseInt(urlParams.get('seed'), 10);
+			seed = Number.isNan(seed) ? "" : `#${seed}`;
+
+			window.location.replace(`../HTML/${encodeURIComponent(redirectTo)}${seed}`);
 		}
 	</script>
 </body>


### PR DESCRIPTION
The API for this is a little bit gross, but it's both backwards and forwards compatible. This should be used in the LFA when it detects a bomb is ruleseeded.

Usage example:
`https://ktane.timwi.de/redirect?seed=0#Maritime%20Flags`