### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ publish
 *.user
 *.sln.cache
 *.orig
+.DS_Store


### PR DESCRIPTION
> `.DS_Store` is a proprietary Mac/OSX system file that holds attributes/meta-data about the folder it resides in.

MacOS insists on putting this in every folder, so it's good to exclude it so MacOS users can contribute more easily :]