### PR TITLE
add Tags search option

### DIFF
--- a/MainPage.cs
+++ b/MainPage.cs
@@ -127,7 +127,8 @@ namespace KtaneWeb
                                 new DIV { class_ = "search-options" }._(
                                     new SPAN { class_ = "search-option", id = "search-opt-names" }._(new INPUT { type = itype.checkbox, class_ = "search-option-input", id = "search-names" }, new LABEL { for_ = "search-names" }._(translation.searchNames)),
                                     new SPAN { class_ = "search-option", id = "search-opt-authors" }._(new INPUT { type = itype.checkbox, class_ = "search-option-input", id = "search-authors" }, new LABEL { for_ = "search-authors" }._(translation.searchAuthors)),
-                                    new SPAN { class_ = "search-option", id = "search-opt-descriptions" }._(new INPUT { type = itype.checkbox, class_ = "search-option-input", id = "search-descriptions" }, new LABEL { for_ = "search-descriptions" }._(translation.searchDescriptions)))),
+                                    new SPAN { class_ = "search-option", id = "search-opt-descriptions" }._(new INPUT { type = itype.checkbox, class_ = "search-option-input", id = "search-descriptions" }, new LABEL { for_ = "search-descriptions" }._(translation.searchDescriptions)),
+                                    new SPAN { class_ = "search-option", id = "search-opt-tags" }._(new INPUT { type = itype.checkbox, class_ = "search-option-input", id = "search-tags" }, new LABEL { for_ = "search-tags" }._(translation.searchTags)))),
                             new DIV { class_ = "search-container" }._(
                                 new LABEL { for_ = "search-field-mission" }._(translation.searchMission + " "),
                                 new SELECT { id = "search-field-mission", class_ = "sw-focus" }, " ",

--- a/Resources/KtaneWeb.js
+++ b/Resources/KtaneWeb.js
@@ -212,7 +212,7 @@ function initializePage(modules, initIcons, initDocDirs, initFilters, initSelect
     let resultsMode = lStorage.getItem('resultsMode') || 'hide';
     let resultsLimit = lStorage.getItem('resultsLimit') || 20;
 
-    let validSearchOptions = ['names', 'authors', 'descriptions'];
+    let validSearchOptions = ['names', 'authors', 'descriptions', 'tags'];
     let defaultSearchOptions = ['names'];
     let searchOptions = defaultSearchOptions;
     try { searchOptions = JSON.parse(lStorage.getItem('searchOptions')) || defaultSearchOptions; } catch (exc) { }
@@ -947,7 +947,8 @@ function initializePage(modules, initIcons, initDocDirs, initFilters, initSelect
         }
 
         let searchRaw = $("input#search-field").val().toString().toLowerCase().trim();
-        let searchKeywords = searchRaw.split(' ').filter(x => x.length > 0).map(x => x.replace(/’/g, '\'')).map(x => new RegExp(escapeRegExp(x).replace(/colou?/g, 'colou?').replace(/gr[ae]y/g, 'gr[ae]y').replace(/impost[oe]r/g, 'impost[oe]r')));
+        let searchKeywordsRaw = searchRaw.split(' ').filter(x => x.length > 0).map(x => x.replace(/’/g, '\'')).map(x => x.replace(/colou?/g, 'colou?').replace(/gr[ae]y/g, 'gr[ae]y').replace(/impost[oe]r/g, 'impost[oe]r'));
+        let searchKeywords = searchKeywordsRaw.map(x => new RegExp(escapeRegExp(x)));
         const filterEnabledByProfile = $('input#filter-profile-enabled').prop('checked');
         const filterVetoedByProfile = $('input#filter-profile-disabled').prop('checked');
 
@@ -1008,21 +1009,18 @@ function initializePage(modules, initIcons, initDocDirs, initFilters, initSelect
                     searchWhat += ' ' + mod.AllContr?.toLowerCase();
                 else
                     searchWhat += ' ' + mod.Author?.toLowerCase();
-            if (searchOptions.indexOf('descriptions') !== -1 && mod.Descriptions)
-            {
-                let modDescr = mod.Descriptions.filter(d => d.Language == (pageLang ?? "English"))[0] ?? mod.Descriptions.filter(d => d.Language == "English")[0];
-                if (displayDescription)
-                    searchWhat += ' ' + modDescr.Description.toLowerCase();
-                if (displayTags && modDescr.Tags)
-                    searchWhat += ' ' + modDescr.Tags.toLowerCase();
-            }
+            const modDescr = mod.Descriptions?.filter(d => d.Language == (pageLang ?? "English"))[0] ?? mod.Descriptions?.filter(d => d.Language == "English")[0] ?? null;
+            if (searchOptions.indexOf('descriptions') !== -1 && displayDescription && modDescr?.Description)
+                searchWhat += ' ' + modDescr.Description.toLowerCase();
             if (searchBySymbol && mod.Symbol)
                 searchWhat += ' ' + mod.Symbol.toLowerCase();
             if (pageLang)
                 searchWhat += ' ' + mod.localName.toLocaleLowerCase();
 
+            const tags = (searchOptions.indexOf('tags') !== -1 && displayTags && modDescr?.Tags) ? modDescr.Tags.split(",").map(t => t.toLowerCase().trim()) : [];
+
             mod.MatchesFilter = filteredIn;
-            mod.MatchesSearch = searchKeywords.every(x => x.test(searchWhat));
+            mod.MatchesSearch = searchKeywords.every(x => x.test(searchWhat)) || searchKeywordsRaw.every(x => tags.some(tag => tag.startsWith(x)));
             mod.includeInResults = mod.MatchesFilter && mod.MatchesSearch;
 
             if (invertSearch)

--- a/TranslationInfo.cs
+++ b/TranslationInfo.cs
@@ -67,6 +67,7 @@ namespace KtaneWeb
         public string searchNames = "Names";
         public string searchAuthors = "Authors";
         public string searchDescriptions = "Descriptions";
+        public string searchTags = "Tags";
         public string popupLinks = "Links";
         public string popupTools = "Tools";
         public string popupView = "View";


### PR DESCRIPTION
adds an option to search only by Tags (excluding them from Description-only searches) and using a different search method for tags to reduce false positives